### PR TITLE
Vulnerable versions: <= 2.19.1

### DIFF
--- a/lambda/cleanup-rancher-instance/requirements.txt
+++ b/lambda/cleanup-rancher-instance/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.12.5
+requests==2.20.0


### PR DESCRIPTION
Patched version: 2.20.0
The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.